### PR TITLE
Add config option for Meters

### DIFF
--- a/mqtt.cfg
+++ b/mqtt.cfg
@@ -4,3 +4,6 @@ port=1883
 [authentication]
 username=temp
 password=temp
+[meters]
+electricity=True
+gas=False

--- a/mqtt_publisher.py
+++ b/mqtt_publisher.py
@@ -7,7 +7,7 @@ import time
 from datetime import datetime
 
 # Add and setup logging to a file in /root/mqtt which is also where  I  store the  script
-logging.basicConfig(filename='/root/mqtt/mqtt.log',filemode='a',format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',datefmt='%H:%M:%S',level=logging.INFO)
+logging.basicConfig(filename='/root/mqtt/mqtt.log',filemode='a',format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',datefmt='%H:%M:%S',level=logging.ERROR)
 
 logging.info("Running MQTT Publisher")
 
@@ -30,12 +30,19 @@ if config.read("/root/mqtt/mqtt.cfg"):
 		logger.info("Using authentication as defined in mqtt.cfg")
 		username=config.get("authentication","username")
 		password=config.get("authentication","password")
+	meters = config.has_section("meters")
+	if meters:
+		logger.info("Using meters as defined in mqtt.cfg")
+		electricity_meter=config.get("meters","electricty")
+		gas_meter=config.get("meters","gas")
 else:
 	logger.error("Config file mqtt.cfg not found, using defaults")
 	print("deffo")	
 	broker="192.168.1.41"
 	port=1883
 	authentication=False
+	electricity_meter=True
+	gas_meter=True
 # Create a flag in class to track MQTT broker connection success
 mqtt.Client.connected_flag=False
 
@@ -85,7 +92,8 @@ while True:
 	current_timestamp = str(datetime.utcnow())
 	logger.info("Update cycle started "+current_timestamp)
 	# Get elec meter consumption
-	try:
+	if electricity_meter:
+	    try:
 		consump_response = requests.post(han_host + "/get_meter_consumption", json={"meter_type": "elec"})
 		if consump_response.ok:
 			elec_meter_consumption = consump_response.json()["meter_consump"]
@@ -93,10 +101,10 @@ while True:
 			#print("Meter consumption for {} meter: {}".format("elec", elec_meter_consumption))
 		else:
 			logger.error("Error calling elec get_meter_consumption API: {}".format(consump_response.json()["Status"]))
-	except:
+	    except:
 		logger.error("Error in elec  get_meter_consumption API try block")
 	# Get elec meter status
-	try:
+	    try:
 		status_response = requests.post(han_host + "/get_meter_status", json={"meter_type": "elec"})
 		if status_response.ok:
 			elec_meter_status = status_response.json()["meter_status"]
@@ -104,10 +112,11 @@ while True:
 			#print("Meter status for {} meter: {}".format("elec", elec_meter_status))
 		else:
 			logger.error("Error calling get_meter_status API: {}".format(elec_meter_status_response.json()["Status"]))
-	except:
+	    except:
 			logger.error("Error in elec  get_meter_consumption API try block")
 	# Get gas  meter consumption
-	try:
+	if gas_meter:
+	    try:
 		gas_consump_response = requests.post(han_host + "/get_meter_consumption", json={"meter_type": "gas"})
 		if gas_consump_response.ok:
 			gas_meter_consumption = gas_consump_response.json()["meter_consump"]
@@ -115,10 +124,10 @@ while True:
 			#print("Meter consumption for {} meter: {}".format("gas", gas_meter_consumption))
 		else:
 			logger.error("Error calling get_meter_consumption API: {}".format(gas_consump_response.json()["Status"]))
-	except:
+	    except:
 			logger.error("Error in Gas  get_meter_consumption API try block")
 	# Get gas meter status
-	try:
+	    try:
 		gas_status_response = requests.post(han_host + "/get_meter_status", json={"meter_type": "gas"})
 		if gas_status_response.ok:
 			gas_meter_status = gas_status_response.json()["meter_status"]
@@ -126,14 +135,16 @@ while True:
 			#print("Meter status for {} meter: {}".format("gas", gas_meter_status))
 		else:
 			logger.error("Error calling get_meter_status API: {}".format(gas_meter_status_response.json()["Status"]))
-	except:
+	    except:
 			logger.error("Error in gas  get_meter_status API try block")
 	#Publish to  MQTT Broker
 	try:
-		ret= client.publish("homepro/elec_meter",elec_meter_consumption)
-		ret2 = client.publish("homepro/elect_meter_status", elec_meter_status)
-		ret3 = client.publish("homepro/gas_meter", gas_meter_consumption)
-		ret4 = client.publish("homepro/gas_meter_status", gas_meter_status)
+		if electricity_meter:
+		    ret= client.publish("homepro/elec_meter",elec_meter_consumption)
+		    ret2 = client.publish("homepro/elect_meter_status", elec_meter_status)
+		if gas_meter:
+		    ret3 = client.publish("homepro/gas_meter", gas_meter_consumption)
+		    ret4 = client.publish("homepro/gas_meter_status", gas_meter_status)
 	except:
 		logger.error("Error in publishing MQTT data")
 	time.sleep(5)

--- a/mqtt_publisher.py
+++ b/mqtt_publisher.py
@@ -33,8 +33,8 @@ if config.read("/root/mqtt/mqtt.cfg"):
 	meters = config.has_section("meters")
 	if meters:
 		logger.info("Using meters as defined in mqtt.cfg")
-		electricity_meter=config.get("meters","electricty")
-		gas_meter=config.get("meters","gas")
+		electricity_meter=config.get("meters","electricity")=="True"
+		gas_meter=config.get("meters","gas")=="True"
 else:
 	logger.error("Config file mqtt.cfg not found, using defaults")
 	print("deffo")	
@@ -93,58 +93,58 @@ while True:
 	logger.info("Update cycle started "+current_timestamp)
 	# Get elec meter consumption
 	if electricity_meter:
-	    try:
-		consump_response = requests.post(han_host + "/get_meter_consumption", json={"meter_type": "elec"})
-		if consump_response.ok:
-			elec_meter_consumption = consump_response.json()["meter_consump"]
-			logger.info("Electricity Consumption returned")
-			#print("Meter consumption for {} meter: {}".format("elec", elec_meter_consumption))
-		else:
-			logger.error("Error calling elec get_meter_consumption API: {}".format(consump_response.json()["Status"]))
-	    except:
-		logger.error("Error in elec  get_meter_consumption API try block")
-	# Get elec meter status
-	    try:
-		status_response = requests.post(han_host + "/get_meter_status", json={"meter_type": "elec"})
-		if status_response.ok:
-			elec_meter_status = status_response.json()["meter_status"]
-			logger.info("Electricity Meter Status returned")
-			#print("Meter status for {} meter: {}".format("elec", elec_meter_status))
-		else:
-			logger.error("Error calling get_meter_status API: {}".format(elec_meter_status_response.json()["Status"]))
-	    except:
+		try:
+			consump_response = requests.post(han_host + "/get_meter_consumption", json={"meter_type": "elec"})
+			if consump_response.ok:
+				elec_meter_consumption = consump_response.json()["meter_consump"]
+				logger.info("Electricity Consumption returned")
+				#print("Meter consumption for {} meter: {}".format("elec", elec_meter_consumption))
+			else:
+				logger.error("Error calling elec get_meter_consumption API: {}".format(consump_response.json()["Status"]))
+		except:
+			logger.error("Error in elec  get_meter_consumption API try block")
+			# Get elec meter status
+		try:
+			status_response = requests.post(han_host + "/get_meter_status", json={"meter_type": "elec"})
+			if status_response.ok:
+				elec_meter_status = status_response.json()["meter_status"]
+				logger.info("Electricity Meter Status returned")
+				#print("Meter status for {} meter: {}".format("elec", elec_meter_status))
+			else:
+				logger.error("Error calling get_meter_status API: {}".format(elec_meter_status_response.json()["Status"]))
+		except:
 			logger.error("Error in elec  get_meter_consumption API try block")
 	# Get gas  meter consumption
 	if gas_meter:
-	    try:
-		gas_consump_response = requests.post(han_host + "/get_meter_consumption", json={"meter_type": "gas"})
-		if gas_consump_response.ok:
-			gas_meter_consumption = gas_consump_response.json()["meter_consump"]
-			logger.info("Gas Consumption returned")
-			#print("Meter consumption for {} meter: {}".format("gas", gas_meter_consumption))
-		else:
-			logger.error("Error calling get_meter_consumption API: {}".format(gas_consump_response.json()["Status"]))
-	    except:
+		try:
+			gas_consump_response = requests.post(han_host + "/get_meter_consumption", json={"meter_type": "gas"})
+			if gas_consump_response.ok:
+				gas_meter_consumption = gas_consump_response.json()["meter_consump"]
+				logger.info("Gas Consumption returned")
+				#print("Meter consumption for {} meter: {}".format("gas", gas_meter_consumption))
+			else:
+				logger.error("Error calling get_meter_consumption API: {}".format(gas_consump_response.json()["Status"]))
+		except:
 			logger.error("Error in Gas  get_meter_consumption API try block")
 	# Get gas meter status
-	    try:
-		gas_status_response = requests.post(han_host + "/get_meter_status", json={"meter_type": "gas"})
-		if gas_status_response.ok:
-			gas_meter_status = gas_status_response.json()["meter_status"]
-			logger.info("Gas Meter Status returned")
-			#print("Meter status for {} meter: {}".format("gas", gas_meter_status))
-		else:
-			logger.error("Error calling get_meter_status API: {}".format(gas_meter_status_response.json()["Status"]))
-	    except:
+		try:
+			gas_status_response = requests.post(han_host + "/get_meter_status", json={"meter_type": "gas"})
+			if gas_status_response.ok:
+				gas_meter_status = gas_status_response.json()["meter_status"]
+				logger.info("Gas Meter Status returned")
+				#print("Meter status for {} meter: {}".format("gas", gas_meter_status))
+			else:
+				logger.error("Error calling get_meter_status API: {}".format(gas_meter_status_response.json()["Status"]))
+		except:
 			logger.error("Error in gas  get_meter_status API try block")
 	#Publish to  MQTT Broker
 	try:
 		if electricity_meter:
-		    ret= client.publish("homepro/elec_meter",elec_meter_consumption)
-		    ret2 = client.publish("homepro/elect_meter_status", elec_meter_status)
+			ret= client.publish("homepro/elec_meter",elec_meter_consumption)
+			ret2 = client.publish("homepro/elect_meter_status", elec_meter_status)
 		if gas_meter:
-		    ret3 = client.publish("homepro/gas_meter", gas_meter_consumption)
-		    ret4 = client.publish("homepro/gas_meter_status", gas_meter_status)
+			ret3 = client.publish("homepro/gas_meter", gas_meter_consumption)
+			ret4 = client.publish("homepro/gas_meter_status", gas_meter_status)
 	except:
 		logger.error("Error in publishing MQTT data")
 	time.sleep(5)


### PR DESCRIPTION
Hi
I've added a config file option and example for the meters, so you can pick whether to send messages for each of Gas/Electric. (I don't have a gas meter and the original version sends instantaneous and total consumption values of 0).
I've also have changed the default logging level to Error for now (this suited my purposes). Feel free to change it back.
It might make sense to put the log level into the config file - I'll have a look at that if I get time at some point in the next week or so.
Cheers
MuddyRock